### PR TITLE
test: 在 test2 验证 xparse v2.2.1 Skill 合并

### DIFF
--- a/skills/xparse-parse/SKILL.md
+++ b/skills/xparse-parse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xparse-parse
-description: "Parse PDFs, images, Office files, HTML, OFD, and other supported documents into Markdown or structured JSON through xparse-cli. Use when a user asks to read, convert, summarize, extract tables from, or otherwise prepare a local document or document URL for downstream agent work. Purchase paid PDF-to-Markdown credits at https://www.textin.com/market/chager/pdf_to_markdown."
+description: "Parse PDFs, images, Office files, HTML, OFD, and other supported documents into Markdown or structured JSON through xparse-cli, then navigate outlines or search and read selected sections when the user needs targeted answers. Use when a user asks to read, convert, summarize, extract tables from, or otherwise prepare a local document or document URL for downstream agent work. Purchase paid PDF-to-Markdown credits at https://www.textin.com/market/chager/pdf_to_markdown."
 ---
 
 # xparse-parse
@@ -68,13 +68,19 @@ xparse-cli --profile workbuddy --task-context <CONTEXT_FILE> parse <INPUT> --api
 
 ## Workflow
 
-1. Confirm the input path or URL.
-2. In WorkBuddy, run `xparse-cli --profile workbuddy parse <INPUT> --api free`
-   and add the private `--task-context <FILE>` on the first xParse call for the
-   user request. Outside WorkBuddy, run `xparse-cli parse <INPUT> --api free`.
-3. Read the result before requesting more detail.
-4. Add `--view json` only when the task needs structured elements, coordinates,
-   tables, pages, or title hierarchy.
+1. Confirm the input path or URL and decide whether the task needs the complete
+   parse result or only selected facts or sections.
+2. For complete conversion, summarization, or export, run
+   `xparse-cli --profile workbuddy parse <INPUT> --api free` in WorkBuddy and
+   add the private `--task-context <FILE>` on the first xParse call. Outside
+   WorkBuddy, omit the profile.
+3. For targeted reading of a local document, follow
+   [navigation.md](references/navigation.md): register the document with
+   `get_doc_info`, parse it once, then use its `doc_id` with outline, search,
+   page, and content-reading commands. Do not dump the whole document when a
+   narrow read can answer the request.
+4. Add `--view json` when the task needs structured elements, coordinates,
+   tables, pages, title hierarchy, or the `doc_id` used by navigation commands.
 5. Add `--output <PATH>` when the user asks to save the result.
 6. Retry a transient failure once at most. Never silently skip a failed parse.
 
@@ -133,6 +139,10 @@ xparse-cli parse report.pdf --api free              # Markdown → stdout
 | Encrypted doc | `xparse-cli parse <FILE> --api free --password <PWD>` |
 | Character details (bbox, confidence, candidate per char) | `xparse-cli parse <FILE> --api free --view json --output <DIR> --include-char-details` |
 | Show free quota | `xparse-cli quota` |
+| Inspect local document | `xparse-cli get_doc_info <FILE>` |
+| Get parsed outline | `xparse-cli get_outline <DOC_ID>` |
+| Search parsed text | `xparse-cli search_text <DOC_ID> <PATTERN>` |
+| Read selected section | `xparse-cli read_content <DOC_ID> <ELEMENT_ID>` |
 | Explicit paid OAuth | `xparse-cli parse <FILE> --api paid --auth-method oauth` |
 | Explicit paid AppKey | `xparse-cli parse <FILE> --api paid --auth-method app-key` |
 
@@ -155,13 +165,15 @@ operation.
 
 ## Routing and stopping rules
 
-1. Confirm the document should be parsed with `xparse-parse`
-2. Run `xparse-cli parse <FILE> --api free --output <DIR>`
+1. Confirm the document should be parsed with `xparse-parse`.
+2. For a full result, run `xparse-cli parse <FILE> --api free --output <DIR>`.
    - **Always use `--output <DIR>`** (a directory path, not a filename) for PDFs — output is often long and will be truncated in the terminal. Example: `xparse-cli parse report.pdf --output ./` saves `report.md` in the current directory.
-3. Read the result file
-4. Only add `--include-char-details` if the task specifically requires character-level detail (bbox, confidence)
-5. If required input is missing, stop and ask the user
-6. If `xparse-parse` clearly cannot solve the task, explain why before switching tools
+3. For a targeted local-document question, use the navigation workflow instead
+   of reading the complete output.
+4. Read the result file or the selected navigation results.
+5. Only add `--include-char-details` if the task specifically requires character-level detail (bbox, confidence).
+6. If required input is missing, stop and ask the user.
+7. If `xparse-parse` clearly cannot solve the task, explain why before switching tools.
 
 Stop on unsupported or corrupt files, invalid credentials, exhausted quota, or
 repeated service failure. Retry a transient service failure once at most.
@@ -172,6 +184,8 @@ repeated service failure. Retry a transient service failure once at most.
   standalone AppKey/Device/browser login, headless behavior, and isolation.
 - [cli-guidance.md](references/cli-guidance.md): output modes, limits, and
   common commands.
+- [navigation.md](references/navigation.md): plan-then-batch outline, search,
+  page, and selected-content reading for parsed local documents.
 - [api-reference.md](references/api-reference.md): parameters, response fields,
   and service error codes.
 - [error-handling.md](references/error-handling.md): retry and stop decisions.

--- a/skills/xparse-parse/references/cli-guidance.md
+++ b/skills/xparse-parse/references/cli-guidance.md
@@ -46,7 +46,7 @@ See [authentication.md](authentication.md) for all login modes and
 | 文件类型 | PDF + 图片（jpg/jpeg/png/bmp/tiff/webp） | 所有支持类型（Doc(x)/Ppt(x)/Xls(x)/HTML/OFD/RTF 等） |
 | 单次文件大小 | ≤ 10 MB | ≤ 500 MB |
 | 单次页数 | ≤ 50 页 | ≤ 1000 页 |
-| 每日页数 | 单 IP ≤ 1000 页/天（UTC+8 零点重置） | 按账户余额扣费，无每日上限 |
+| 每日页数 | 单 IP ≤ 500 页/天（UTC+8 零点重置） | 按账户余额扣费，无每日上限 |
 | 频率控制 | 1 次/秒/IP | QPS 限流（按账户配置） |
 | 认证 | 无需认证（IP 标识） | OAuth Bearer 或 AppKey + Secret |
 

--- a/skills/xparse-parse/references/navigation.md
+++ b/skills/xparse-parse/references/navigation.md
@@ -1,0 +1,73 @@
+# Targeted Document Navigation
+
+Use this workflow when the user needs selected facts, tables, pages, or
+sections from a local document. For a complete Markdown or JSON result, use the
+normal `parse` workflow in `SKILL.md`.
+
+Inside WorkBuddy, insert `--profile workbuddy` immediately after `xparse-cli`
+for every command. Apply the task-context rule from `SKILL.md` only to the first
+xParse command for the user request.
+
+## Standard workflow
+
+1. Run `get_doc_info <FILE>` to validate the local file and obtain its stable
+   `doc_id` and `page_count` without a service call.
+2. Run `parse <FILE> --api free --view json`. A successful v2.2.1 parse writes
+   the navigation cache and exposes the same `doc_id` in its JSON result or
+   diagnostic metadata.
+3. Complete navigation with `get_outline`, `search_text`, or `read_pages`.
+4. Read only the selected elements with `read_content`.
+
+Do not generate the deprecated cache-preparation command. If `parse` succeeds
+but does not expose a usable `doc_id`, stop and update the Connector-managed CLI
+instead of inventing an ID or reparsing through another tool.
+
+## Plan-then-Batch execution
+
+Finish navigation before reading content:
+
+1. List every section or fact needed for the answer.
+2. If an outline is truncated, complete all relevant `--parent-id` drill-downs.
+3. Use scoped searches to locate precise facts inside large sections.
+4. Issue independent `read_content` and `search_text` calls in one parallel
+   tool-call message when the host supports parallel calls.
+
+Target at most eight `read_content` calls. Prefer a parent section over many
+small child reads, and prefer a search hit's context when it already answers
+the question.
+
+## Navigation decision table
+
+| User intent | Action sequence |
+|---|---|
+| Known section, complete outline | `get_outline` → `read_content` |
+| Known section, truncated outline | `get_outline` → drill down with `--parent-id` → `read_content` |
+| Known keyword, unknown location | `search_text` → use hit context or read the returned element |
+| Known keyword within a section | `get_outline` → `search_text --scope <SECTION_ID>` → optional `read_content` |
+| Known page range | `read_pages <DOC_ID> <START> <END>`; at most 20 pages per call |
+| No usable headings | `search_text` → fall back to bounded `read_pages` |
+
+Never guess an `element_id`. When `truncated=true`, drill down before reading a
+section.
+
+## Command reference
+
+| Command | Purpose |
+|---|---|
+| `xparse-cli get_doc_info <FILE>` | Return local `doc_id`, `page_count`, and document type |
+| `xparse-cli get_outline <DOC_ID> [--depth N] [--parent-id <ID>]` | Read the cached title hierarchy |
+| `xparse-cli search_text <DOC_ID> <PATTERN> [--scope <ID>]` | Search cached text and return context plus element IDs |
+| `xparse-cli read_content <DOC_ID> <ELEMENT_ID>` | Read one section, table, or paragraph |
+| `xparse-cli read_pages <DOC_ID> <START> <END>` | Read a bounded page range from cache |
+| `xparse-cli get_confidence <DOC_ID> --element-id <ID>` | Inspect OCR confidence only when quality is uncertain |
+
+## Recovery and stopping rules
+
+- Cache miss after a successful parse: retry the parse once only if the failure
+  is transient; otherwise stop and report a CLI compatibility problem.
+- Unknown `doc_id`: rerun `get_doc_info` for the exact local path.
+- Unknown `element_id`: refresh the outline or search result; never guess.
+- Page range too large: split it into ranges of at most 20 pages.
+- Exhausted quota, unsupported or encrypted input, invalid credentials, or a
+  repeated service failure: follow `error-handling.md` and stop when it says to
+  request user action.


### PR DESCRIPTION
## 目的

将 xParse v2.2.1 的 Skill 合并与国内 500 页文案先纳入 `test2`，专用于 TEST/PRE 阶段验证。

## 提交

- `6781baf`：统一国内免费额度说明为每日 500 页
- `cb86a4e`：合并文档解析与定向阅读 Skill

## 环境边界

- 本 PR 目标仅为 `test2`
- 不修改 `main`
- 不修改既有 `test`
- TEST、PRE 验收通过后，再另行创建指向 `main` 的正式 PR
